### PR TITLE
Add global namespace from namespaceset

### DIFF
--- a/pkg/agent/entry.go
+++ b/pkg/agent/entry.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
+	_ "net/http/pprof" //nolint: gosec // enable profiler
 	"net/url"
 	"os"
 	"strings"
@@ -55,7 +55,7 @@ func Run(cliContext *cli.Context) {
 	}
 	cfg.proxyURL = proxyURL
 
-	accessTokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	accessTokenPath := "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint: gosec // read token from file
 	accessTokenBytes, err := os.ReadFile(accessTokenPath)
 	if err != nil {
 		log.WithError(err).Panicf("Failed to read token file %q", accessTokenPath)

--- a/pkg/agent/http_api_context.go
+++ b/pkg/agent/http_api_context.go
@@ -17,9 +17,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 )
 
-const (
-	apiContextKey = "_apiContext_"
-)
+type apiContextKeyT string
+
+const apiContextKey apiContextKeyT = "_apiContextKey_"
 
 var (
 	badRequestErr     = errors.BadRequestf("bad_data")
@@ -115,14 +115,6 @@ func (c *apiContext) responseMetrics(data *promgo.MetricFamily) (err error) {
 	return
 }
 
-func (c *apiContext) proxy() error {
-	c.Do(func() {
-		c.proxyHandler.ServeHTTP(c.response, c.request)
-	})
-
-	return nil
-}
-
 func (c *apiContext) proxyWith(request *http.Request) error {
 	c.Do(func() {
 		c.proxyHandler.ServeHTTP(c.response, request)
@@ -142,7 +134,6 @@ func (f apiContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := f(apiCtx)
 	if err == nil {
-		log.Debugf("api context response: %+v", apiCtx.response)
 		return
 	}
 

--- a/pkg/agent/http_api_context.go
+++ b/pkg/agent/http_api_context.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync"
 
@@ -143,8 +142,7 @@ func (f apiContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := f(apiCtx)
 	if err == nil {
-		resp, _ := apiCtx.response.(*httptest.ResponseRecorder)
-		log.Debugf("sucessful proxy of request. Len of response: %d", resp.Body.Len())
+		log.Infof("api context response: %v", apiCtx.response)
 		return
 	}
 

--- a/pkg/agent/http_api_context.go
+++ b/pkg/agent/http_api_context.go
@@ -142,7 +142,7 @@ func (f apiContextHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	err := f(apiCtx)
 	if err == nil {
-		log.Infof("api context response: %v", apiCtx.response)
+		log.Debugf("api context response: %+v", apiCtx.response)
 		return
 	}
 

--- a/pkg/agent/http_hijack.go
+++ b/pkg/agent/http_hijack.go
@@ -59,7 +59,7 @@ func hijackFederate(apiCtx *apiContext) error {
 
 		log.Debugf("raw federate[%s - %d] => %s", apiCtx.tag, idx, rawValue)
 		hjkValue := modifyExpression(expr, apiCtx.namespaceSet)
-		log.Infof("hjk federate[%s - %d] => %s", apiCtx.tag, idx, hjkValue)
+		log.Debugf("hjk federate[%s - %d] => %s", apiCtx.tag, idx, hjkValue)
 
 		queries.Add("match[]", hjkValue)
 	}


### PR DESCRIPTION
## Motivation

Closes https://gitlab.devops.telekom.de/caas/rancher/prometheus-auth/-/issues/1

## Tests

- Unittests pass
- Tested in test cluster, affected user is now getting all metrics federate metrics (the image shows just one of the kube-state-metrics one

![image](https://github.com/caas-team/prometheus-auth/assets/52347078/44600947-29ab-47ca-b901-f5927dd4fd7f)

Logs from the auth pod:

```
INFO[2024-01-02T16:15:19Z] hjk federate[0000000065943697 - 0] => {__name__=~".+",namespace=~"actinium-dev|actinium-test|caasglobal|cattle-project-p-c-kpg24|dev-10317|dev-11965|dev-17380|dev-18787|dev-22177|dev-2632|dev-32945|dev-4400|dev-54565|dev-8074|dev-8692|dev-8986|dev-8988|dev-9055|dev-9144|dev-9284|dhvoice|voice-logging|voyager-test"}
DEBU[2024-01-02T16:15:20Z] GET - /federate
DEBU[2024-01-02T16:15:20Z] raw federate[0000000065943698 - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:20Z] hjk federate[0000000065943698 - 0] => {__name__=~".+",namespace=~"caasglobal|cit4|thop-cit4-monitoring-v3"}
DEBU[2024-01-02T16:15:21Z] GET - /federate
DEBU[2024-01-02T16:15:21Z] raw federate[0000000065943699 - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:21Z] hjk federate[0000000065943699 - 0] => {__name__=~".+",namespace=~"caasglobal|comodel|comodel-dev|gnrdev|monitoring"}
DEBU[2024-01-02T16:15:24Z] GET - /federate
DEBU[2024-01-02T16:15:24Z] raw federate[000000006594369c - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:24Z] hjk federate[000000006594369c - 0] => {__name__=~".+",namespace=~"atk-pre-integrationstest|caasglobal"}
DEBU[2024-01-02T16:15:24Z] GET - /federate
DEBU[2024-01-02T16:15:24Z] raw federate[000000006594369c - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:24Z] hjk federate[000000006594369c - 0] => {__name__=~".+",namespace=~"caasglobal|self-service-landtake-demo"}
DEBU[2024-01-02T16:15:25Z] GET - /federate
DEBU[2024-01-02T16:15:25Z] raw federate[000000006594369d - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:25Z] hjk federate[000000006594369d - 0] => {__name__=~".+",namespace=~"caasglobal|neo"}
DEBU[2024-01-02T16:15:25Z] GET - /federate
DEBU[2024-01-02T16:15:25Z] raw federate[000000006594369d - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:25Z] hjk federate[000000006594369d - 0] => {__name__=~".+",namespace=~"caasglobal|tmfopenapi-int"}
DEBU[2024-01-02T16:15:25Z] GET - /federate
DEBU[2024-01-02T16:15:25Z] raw federate[000000006594369d - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:25Z] hjk federate[000000006594369d - 0] => {__name__=~".+",namespace=~"caasglobal|vpgw-test"}
DEBU[2024-01-02T16:15:25Z] GET - /federate
DEBU[2024-01-02T16:15:25Z] raw federate[000000006594369d - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:25Z] hjk federate[000000006594369d - 0] => {__name__=~".+",namespace=~"caasglobal|tmfopenapi"}
DEBU[2024-01-02T16:15:25Z] GET - /federate
DEBU[2024-01-02T16:15:25Z] raw federate[000000006594369d - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:25Z] hjk federate[000000006594369d - 0] => {__name__=~".+",namespace=~"atk-keycloak-etau|caasglobal|monitoring-atk-keycloak-etau-v3"}
DEBU[2024-01-02T16:15:27Z] GET - /federate
DEBU[2024-01-02T16:15:27Z] raw federate[000000006594369f - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:27Z] hjk federate[000000006594369f - 0] => {__name__=~".+",namespace=~"caasglobal|knime|t21-v3-monitoring"}
DEBU[2024-01-02T16:15:27Z] GET - /federate
DEBU[2024-01-02T16:15:27Z] raw federate[000000006594369f - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:27Z] hjk federate[000000006594369f - 0] => {__name__=~".+",namespace=~"caasglobal|thop-cit2|thop-cit2-monitoring-v3"}
DEBU[2024-01-02T16:15:28Z] GET - /federate
DEBU[2024-01-02T16:15:28Z] raw federate[00000000659436a0 - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:28Z] hjk federate[00000000659436a0 - 0] => {__name__=~".+",namespace=~"caasglobal|tivu-cit2|tivu-cit4|tivu-dev|tivu-logging|tivu-monitoring|tivu-test"}
DEBU[2024-01-02T16:15:29Z] GET - /federate
DEBU[2024-01-02T16:15:29Z] raw federate[00000000659436a1 - 0] => {__name__=~".+"}
INFO[2024-01-02T16:15:29Z] hjk federate[00000000659436a1 - 0] => {__name__=~".+",namespace=~"caasglobal|vpgw-ref"}
DEBU[2024-01-02T16:15:29Z] GET - /federate
```

