### PR TITLE
chore: removed old api group

### DIFF
--- a/pkg/agent/http_api_context.go
+++ b/pkg/agent/http_api_context.go
@@ -66,7 +66,7 @@ func (c *apiContext) responseJSON(data interface{}) (err error) {
 		}
 	})
 
-	return
+	return err
 }
 
 func (c *apiContext) responseProto(data proto.Message) (err error) {
@@ -92,7 +92,7 @@ func (c *apiContext) responseProto(data proto.Message) (err error) {
 		}
 	})
 
-	return
+	return err
 }
 
 func (c *apiContext) responseMetrics(data *promgo.MetricFamily) (err error) {
@@ -112,7 +112,7 @@ func (c *apiContext) responseMetrics(data *promgo.MetricFamily) (err error) {
 		}
 	})
 
-	return
+	return err
 }
 
 func (c *apiContext) proxyWith(request *http.Request) error {

--- a/pkg/agent/http_hijack.go
+++ b/pkg/agent/http_hijack.go
@@ -330,7 +330,7 @@ func hijackRead(apiCtx *apiContext) error {
 		size := len(rawQueries)
 
 		results := make([]*prompb.QueryResult, 0, size)
-		for i := 0; i < size; i++ {
+		for range size {
 			results = append(results, &prompb.QueryResult{})
 		}
 

--- a/pkg/agent/http_test.go
+++ b/pkg/agent/http_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/juju/errors"
 	"github.com/prometheus/prometheus/promql/promqltest"
 
 	"github.com/caas-team/prometheus-auth/pkg/agent/test"
@@ -551,7 +552,7 @@ func (v ScenarioValidator) validateProtoBody(t *testing.T, res *httptest.Respons
 }
 
 func (v ScenarioValidator) validateJSONBody(t *testing.T, res *httptest.ResponseRecorder) {
-	if got, want := string(res.Body.Bytes()), jsonResponseBody(v.Scenario.RespBody); got != want {
+	if got, want := res.Body.String(), jsonResponseBody(v.Scenario.RespBody); got != want {
 		t.Errorf("[%s] [%s] token %q scenario %q: got body\n%s\n, want\n%s\n", v.Type, v.Method, v.Token, v.Name, got, want)
 	}
 }
@@ -641,7 +642,7 @@ type fakeTokenAuth struct {
 func (f *fakeTokenAuth) Authenticate(token string) (authentication.UserInfo, error) {
 	userInfo, ok := f.token2UserInfo[token]
 	if !ok {
-		return userInfo, fmt.Errorf("user is not authenticated")
+		return userInfo, errors.New("user is not authenticated")
 	}
 	return userInfo, nil
 }

--- a/pkg/prom/matcher.go
+++ b/pkg/prom/matcher.go
@@ -1,7 +1,7 @@
 package prom
 
 import (
-	"fmt"
+	"errors"
 
 	promlb "github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/prompb"
@@ -86,7 +86,7 @@ func toLabelMatchers(matchers []*promlb.Matcher) ([]*prompb.LabelMatcher, error)
 		case promlb.MatchNotRegexp:
 			mType = prompb.LabelMatcher_NRE
 		default:
-			return nil, fmt.Errorf("invalid matcher type")
+			return nil, errors.New("invalid matcher type")
 		}
 		pbMatchers = append(pbMatchers, &prompb.LabelMatcher{
 			Type:  mType,
@@ -111,7 +111,7 @@ func fromLabelMatchers(matchers []*prompb.LabelMatcher) ([]*promlb.Matcher, erro
 		case prompb.LabelMatcher_NRE:
 			mtype = promlb.MatchNotRegexp
 		default:
-			return nil, fmt.Errorf("invalid matcher type")
+			return nil, errors.New("invalid matcher type")
 		}
 		matcher, err := promlb.NewMatcher(mtype, matcher.Name, matcher.Value)
 		if err != nil {


### PR DESCRIPTION
## Motivation

In preparation for the upcoming v1.0.0 of CaaS Cluster Monitoring, the prometheus auth will be updated to not contain the old rancher monitoring API.

## Changes

Eliminate the old Rancher API group marked for removal, enhancing error handling by replacing `fmt.Errorf` with `errors.New` in various locations. Additionally, ensure consistent return values in response functions.

## Tests done

Deployed in a cluster with the v1.0.0-rc4 cluster-monitoring enabled. Logs from a mixed setup of project monitoring instances show the expected behavior:

```shell
DEBU[2025-01-21T14:28:09Z] GET - /federate                              
DEBU[2025-01-21T14:28:09Z] sending access review for namespace "demoapp" 
WARN[2025-01-21T14:28:09Z] failed to query Namespaces: failed validation: token is not allowed to access namespace "demoapp" 

DEBU[2025-01-21T14:32:25Z] GET - /federate
DEBU[2025-01-21T14:32:25Z] token for ns "caas-operations-monitoring" is cached
DEBU[2025-01-21T14:32:25Z] searching for namespace "caas-operations-monitoring" in cache
DEBU[2025-01-21T14:32:25Z] raw federate[00000000678faff9 - 0] => {__name__=~".+"}
DEBU[2025-01-21T14:32:25Z] hjk federate[00000000678faff9 - 0] => {__name__=~".+",namespace=~"caas-cert-manager|caas-eck-operator|caas-keda|caas-operations-monitoring|caasglobal|cattle-gatekeeper-system|cattle-project-caas-operations|cluster-autoscaler|cosignwebhook|crossplane-system|namespace-provisioner-system|navlinkswebhook|ranchertoicinga2|vpa-system|vpa-test"}
```

The demoapp namespace has an old project monitoring installed:

```
❯ helm ls -n demoapp
NAME                            NAMESPACE       REVISION        UPDATED                                         STATUS          CHART                           APP VERSION
demomon                         demoapp         27              2023-10-13 11:40:35.612281 +0200 CEST           deployed        caas-project-monitoring-1.2.0   51.0.3
```

While the `caas-operations-monitoring` is a target namespace of a newer, compatible version:

```
❯ helm ls -n caas-operations-monitoring
NAME                            NAMESPACE                       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
caas-operations-monitoring      caas-operations-monitoring      9               2024-12-05 13:07:00.009243007 +0000 UTC deployed        caas-project-monitoring-1.3.0   58.4.0
```

After upgrading the old monitoring of the `demoapp` to the new one, the problem goes away 🏄‍♂️:

```
DEBU[2025-01-21T15:06:56Z] GET - /federate                       
DEBU[2025-01-21T15:06:56Z] sending access review for namespace "demoapp"
DEBU[2025-01-21T15:06:56Z] searching for namespace "demoapp" in cache
DEBU[2025-01-21T15:06:56Z] raw federate[00000000678fb810 - 0] => {__name__=~".+"}
DEBU[2025-01-21T15:06:56Z] hjk federate[00000000678fb810 - 0] => {__name__=~".+",namespace=~"caasglobal|demoapp|demoapp2|demoapp3|democluster"}
```