### PR TITLE
feat: added oidc issuer flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ GLOBAL OPTIONS:
    --listen-address value        [optional] Address to listening (default: ":9090")
    --proxy-url value             [optional] URL to proxy (default: "http://localhost:9999")
    --read-timeout value          [optional] Maximum duration before timing out read of the request, and closing idle connections (default: 5m0s)
+   --oidc-issuer value           [optional] OIDC issuer URL (default: "https://rancher.example.com")
    --max-connections value       [optional] Maximum number of simultaneous connections (default: 512)
    --filter-reader-labels value  [optional] Filter out the configured labels when calling '/api/v1/read'
    --help, -h                    show help

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,11 @@ func main() {
 			Usage: "[optional] Filter out the configured labels when calling '/api/v1/read'",
 			Value: &cli.StringSlice{},
 		},
+		cli.StringFlag{
+			Name:  "oidc-issuer",
+			Usage: "[optional] OIDC issuer URL, used to validate JWT tokens",
+			Value: "",
+		},
 	}
 
 	defer func() {

--- a/pkg/agent/entry.go
+++ b/pkg/agent/entry.go
@@ -42,7 +42,6 @@ func Run(cliContext *cli.Context) {
 		listenAddress:        cliContext.String("listen-address"),
 		readTimeout:          cliContext.Duration("read-timeout"),
 		maxConnections:       cliContext.Int("max-connections"),
-		oidcIssuer:           cliContext.String("oidc-issuer"),
 		filterReaderLabelSet: data.NewSet(cliContext.StringSlice("filter-reader-labels")...),
 	}
 
@@ -66,6 +65,15 @@ func Run(cliContext *cli.Context) {
 		log.Panicf("Read empty token from file %q", accessTokenPath)
 	}
 	cfg.myToken = accessToken
+
+	oidcURLString := cliContext.String("oidc-issuer")
+	if len(oidcURLString) > 0 {
+		oidcURL, pErr := url.Parse(oidcURLString)
+		if pErr != nil {
+			log.Panicf("Unable to parse OIDC issuer URL %q", oidcURLString)
+		}
+		cfg.oidcIssuer = oidcURL.String()
+	}
 
 	log.Println(cfg)
 

--- a/pkg/agent/entry.go
+++ b/pkg/agent/entry.go
@@ -42,6 +42,7 @@ func Run(cliContext *cli.Context) {
 		listenAddress:        cliContext.String("listen-address"),
 		readTimeout:          cliContext.Duration("read-timeout"),
 		maxConnections:       cliContext.Int("max-connections"),
+		oidcIssuer:           cliContext.String("oidc-issuer"),
 		filterReaderLabelSet: data.NewSet(cliContext.StringSlice("filter-reader-labels")...),
 	}
 
@@ -86,6 +87,7 @@ type agentConfig struct {
 	readTimeout          time.Duration
 	maxConnections       int
 	filterReaderLabelSet data.Set
+	oidcIssuer           string
 }
 
 func (a *agentConfig) String() string {
@@ -198,7 +200,7 @@ func createAgent(ctx context.Context, cfg *agentConfig) (*agent, error) {
 		cfg:        cfg,
 		userInfo:   userInfo,
 		listener:   listener,
-		namespaces: kube.NewNamespaces(cfg.ctx, k8sClient),
+		namespaces: kube.NewNamespaces(cfg.ctx, k8sClient, cfg.oidcIssuer),
 		tokens:     tokens,
 		remoteAPI:  promapiv1.NewAPI(promClient),
 	}, nil


### PR DESCRIPTION
## Motivation

This makes the prometheus-auth more flexible, in case a non-caas OIDC issuer should be used.

## Changes done

The provider URL is now passed directly via a CLI flag. There is validation done directly, in case a URL should be passed.

To make sure that no OIDC Issuers with a URL of `""` are used (the nil value of the CLI string when a flag isn't provided), a simple struct named `oidc` was introduced, with an `active` property, which is only set, if the issuer URL passed can be actually parsed.

## Discussion

To accommodate this change, the `switch` statement was replaced with multiple ifs. This was in case the user hasn't provided an Issuer URL and in case the claim should have an empty Issuer URL (which _shouldn't_ happen according to the RfC https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1, but wilder things _have happened_). Just playing it safe should be OK, I guess and we're not sacrificing too much readability here.

## Tests done

Tested in an rke1 and rke2 staging cluster with different OIDC Issuer URLs. The validation works as it did before.
